### PR TITLE
Prepare for the updated `pivot_wider()` signature

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,8 +26,10 @@ Imports:
     magrittr,
     rlang,
     tibble,
-    tidyr,
+    tidyr (>= 1.1.4.9000),
     tidyselect
+Remotes:
+    tidyverse/tidyr
 RoxygenNote: 7.1.2
 Suggests: 
     MASS,

--- a/R/tidyverse_verb_methods.R
+++ b/R/tidyverse_verb_methods.R
@@ -2801,20 +2801,25 @@ tidyr::pivot_wider
 #' @rdname tidyverse_verbs
 #' @param data See original function documentation
 #' @param id_cols See original function documentation
+#' @param id_expand See original function documentation
 #' @param names_from See original function documentation
 #' @param names_prefix See original function documentation
 #' @param names_sep See original function documentation
 #' @param names_glue See original function documentation
 #' @param names_sort See original function documentation
+#' @param names_vary See original function documentation
+#' @param names_expand See original function documentation
 #' @param names_repair See original function documentation
 #' @param values_from See original function documentation
 #' @param values_fill See original function documentation
 #' @param values_fn See original function documentation
+#' @param unused_fn See original function documentation
 #' @param \dots See original function documentation
 #' @export
-pivot_wider.simpr_sims = function(data, id_cols = NULL, names_from = NULL, names_prefix = "",
-    names_sep = "_", names_glue = NULL, names_sort = FALSE, names_repair = "check_unique",
-    values_from = NULL, values_fill = NULL, values_fn = NULL,
+pivot_wider.simpr_sims = function(data, id_cols = NULL, id_expand = FALSE, names_from = NULL,
+    names_prefix = "", names_sep = "_", names_glue = NULL, names_sort = FALSE,
+    names_vary = "fastest", names_expand = FALSE, names_repair = "check_unique",
+    values_from = NULL, values_fill = NULL, values_fn = NULL, unused_fn = NULL,
     ...) {
 mc = match.call()
 mc[[1]] = quote(pivot_wider)
@@ -2827,20 +2832,25 @@ data
 #' @rdname tidyverse_verbs
 #' @param data See original function documentation
 #' @param id_cols See original function documentation
+#' @param id_expand See original function documentation
 #' @param names_from See original function documentation
 #' @param names_prefix See original function documentation
 #' @param names_sep See original function documentation
 #' @param names_glue See original function documentation
 #' @param names_sort See original function documentation
+#' @param names_vary See original function documentation
+#' @param names_expand See original function documentation
 #' @param names_repair See original function documentation
 #' @param values_from See original function documentation
 #' @param values_fill See original function documentation
 #' @param values_fn See original function documentation
+#' @param unused_fn See original function documentation
 #' @param \dots See original function documentation
 #' @export
-pivot_wider.simpr_spec = function(data, id_cols = NULL, names_from = NULL, names_prefix = "",
-    names_sep = "_", names_glue = NULL, names_sort = FALSE, names_repair = "check_unique",
-    values_from = NULL, values_fill = NULL, values_fn = NULL,
+pivot_wider.simpr_spec = function(data, id_cols = NULL, id_expand = FALSE, names_from = NULL,
+    names_prefix = "", names_sep = "_", names_glue = NULL, names_sort = FALSE,
+    names_vary = "fastest", names_expand = FALSE, names_repair = "check_unique",
+    values_from = NULL, values_fill = NULL, values_fn = NULL, unused_fn = NULL,
     ...) {
 mc = match.call()
 

--- a/man/tidyverse_verbs.Rd
+++ b/man/tidyverse_verbs.Rd
@@ -755,30 +755,38 @@
 \method{pivot_wider}{simpr_sims}(
   data,
   id_cols = NULL,
+  id_expand = FALSE,
   names_from = NULL,
   names_prefix = "",
   names_sep = "_",
   names_glue = NULL,
   names_sort = FALSE,
+  names_vary = "fastest",
+  names_expand = FALSE,
   names_repair = "check_unique",
   values_from = NULL,
   values_fill = NULL,
   values_fn = NULL,
+  unused_fn = NULL,
   ...
 )
 
 \method{pivot_wider}{simpr_spec}(
   data,
   id_cols = NULL,
+  id_expand = FALSE,
   names_from = NULL,
   names_prefix = "",
   names_sep = "_",
   names_glue = NULL,
   names_sort = FALSE,
+  names_vary = "fastest",
+  names_expand = FALSE,
   names_repair = "check_unique",
   values_from = NULL,
   values_fill = NULL,
   values_fn = NULL,
+  unused_fn = NULL,
   ...
 )
 
@@ -1055,17 +1063,25 @@
 
 \item{id_cols}{See original function documentation}
 
+\item{id_expand}{See original function documentation}
+
 \item{names_from}{See original function documentation}
 
 \item{names_glue}{See original function documentation}
 
 \item{names_sort}{See original function documentation}
 
+\item{names_vary}{See original function documentation}
+
+\item{names_expand}{See original function documentation}
+
 \item{values_from}{See original function documentation}
 
 \item{values_fill}{See original function documentation}
 
 \item{values_fn}{See original function documentation}
+
+\item{unused_fn}{See original function documentation}
 
 \item{sep}{See original function documentation}
 


### PR DESCRIPTION
We are planning to release tidyr 1.2.0 this week.

`pivot_wider()` gained 4 new arguments which you can read about [in the NEWS](https://github.com/tidyverse/tidyr/blob/main/NEWS.md#pivoting).

Unfortunately, because of an edge case in the way S3 method registration works, this causes simpr to break in revdep checking (in particular, this happens because of the specific combination of S3 issues outlined here https://github.com/DavisVaughan/methodtest).

There isn't anything we can do ahead of time to prevent simpr from breaking, but this PR is a first pass at preparing the `pivot_wider()` methods for the next release. I've simply added the new arguments to the signature.

Once tidyr is accepted, you should be able to bump the version requirement, remove the Remote, merge this, and then send a patch release to keep simpr from being removed from CRAN.