### PR TITLE
Fix for dev purrr

### DIFF
--- a/R/apply_fits.R
+++ b/R/apply_fits.R
@@ -82,8 +82,8 @@ apply_fits.simpr_tibble = function(obj, .f, ..., .progress = FALSE,
 
   if(any(grepl("^\\.fit_error", names(obj)))) {
     fit_errors = obj %>%
-      dplyr::select(.data$.sim_id, tidyselect::starts_with(".fit_error_")) %>%
-      tidyr::pivot_longer(-.data$.sim_id, names_to = "Source", values_to = ".fit_error") %>%
+      dplyr::select(".sim_id", tidyselect::starts_with(".fit_error_")) %>%
+      tidyr::pivot_longer(-".sim_id", names_to = "Source", values_to = ".fit_error") %>%
       dplyr::mutate(Source = sub("^^\\.fit_error_", "", .data$Source))
 
     simpr_meta = dplyr::left_join(simpr_meta, fit_errors, by = c(".sim_id"))

--- a/R/generate.R
+++ b/R/generate.R
@@ -125,7 +125,7 @@ generate.simpr_spec = function(x, .reps, ..., .sim_name = "sim",
                            x$conditions,
                            by = character()) %>%
     dplyr::mutate(.sim_id = 1:(dplyr::n())) %>%
-    dplyr::relocate(.data$.sim_id) %>%
+    dplyr::relocate(".sim_id") %>%
     dplyr::relocate(rep, .after = dplyr::everything())
 
   specs_filter = dplyr::filter(specs, ...)

--- a/tests/testthat/test_calc_tidy.R
+++ b/tests/testthat/test_calc_tidy.R
@@ -78,10 +78,10 @@ test_that("Errors show up in tidied output.", {
         .warn_on_error = FALSE) %>%
     tidy_fits()
 
-  expect_equal(buggy_fit$.sim_error,
-               c("Error in rnorm(size): invalid arguments\n",
-                 "Error in rnorm(size): invalid arguments\n",
-                 NA, NA))
+  expect_match(buggy_fit$.sim_error[[1]], "invalid arguments")
+  expect_match(buggy_fit$.sim_error[[2]], "invalid arguments")
+  expect_equal(buggy_fit$.sim_error[[3]], NA_character_)
+  expect_equal(buggy_fit$.sim_error[[4]], NA_character_)
 
   expect_equal(buggy_fit$.fit_error,
                c("Error in t.test(y): object 'y' not found\n",

--- a/tests/testthat/test_errors.R
+++ b/tests/testthat/test_errors.R
@@ -14,6 +14,7 @@ err_out = generate(spec, 30, .warn_on_error = FALSE, .options = furrr_options(se
                                                                                  globals = list(errgt = errgt)))
 
 expect_true(".sim_error" %in% names(err_out))
-expect_true(all(na.omit(err_out$.sim_error) == "Error in errgt(x1): x < 3 are not all TRUE\n"))
+
+expect_true(all(grepl("x < 3 are not all TRUE", na.omit(err_out$.sim_error))))
 
 })


### PR DESCRIPTION
The dev version of purrr now wraps the errors with the index where the error occurred, so your tests needed to be relaxed a bit. And I included a bonus fix for latest tidyselect.